### PR TITLE
Update easyzoom.js

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -199,7 +199,7 @@
         var xl = pl * rw;
 
         // Close if outside
-        if (xl < 0 || xt < 0 || xl > dw || xt > dh) {
+        if (xl < 0 || xt < 0 || xl > dw || Math.floor(xt) > dh) {
             this.hide();
         }
         else {


### PR DESCRIPTION
Fixed the issue with adjacent image not showing up when mouse enters from bottom on images with odd sizes.
