### PR TITLE
Add srcset functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,10 +273,10 @@
 					Removes all events and elements created and attached by EasyZoom.
 				</dd>
 				<dt>
-					<code>.swap(<var>standardSrc</var>, <var>zoomSrc</var>)</code>
+					<code>.swap(<var>standardSrc</var>, <var>zoomSrc</var>, <var>[srcsetStringOrArray]</var>)</code>
 				</dt>
 				<dd>
-					Easily switch the standard and zoom image sources.
+					Easily switch the standard and zoom image sources. To display retina images via the srcset attribute, use the optional srcsetStringOrArray argument.
 				</dd>
 			</dl>
 

--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -229,10 +229,12 @@
      * Swap
      * @param {String} standardSrc
      * @param {String} zoomHref
+     * @param {string|Array.<string>=} srcsetStringOrArray (Optional)
      */
-    EasyZoom.prototype.swap = function(standardSrc, zoomHref) {
+    EasyZoom.prototype.swap = function(standardSrc, zoomHref, srcsetStringOrArray) {
         this.hide();
         this.isReady = false;
+        srcsetStringOrArray = srcsetStringOrArray || '';
 
         if (this.detachNotice) {
             clearTimeout(this.detachNotice);
@@ -242,8 +244,15 @@
             this.$notice.detach();
         }
 
+        if (!typeof srcsetStringOrArray === 'string') {
+            srcsetStringOrArray = srcsetStringOrArray.join();
+        }
+
         this.$target.removeClass('is-loading is-ready is-error');
-        this.$image.attr('src', standardSrc);
+        this.$image.attr({
+            src: standardSrc,
+            srcset: srcsetStringOrArray
+        });
         this.$link.attr('href', zoomHref);
     };
 

--- a/test/spec/easyzoom.js
+++ b/test/spec/easyzoom.js
@@ -127,6 +127,35 @@
 
     });
 
+    test(".swap(standard, zoom, srcsetString)", function() {
+
+        expect(1);
+
+        var standard = "../example-images/test_standard.jpg";
+        var zoom = "../example-images/test_zoom.jpg";
+        var srcsetString = "../example-images/test_standard.jpg 1x, ../example-images/test_zoom.jpg 2x";
+
+        api.swap(standard, zoom, srcsetString);
+
+        equal(api.$image.attr("srcset"), srcsetString, "Standard image SRCSET changed");
+
+    });
+
+    test(".swap(standard, zoom, srcsetArray)", function() {
+
+        expect(1);
+
+        var standard = "../example-images/test_standard.jpg";
+        var zoom = "../example-images/test_zoom.jpg";
+        var srcsetArray = ['../example-images/test_standard.jpg 1x', '../example-images/test_zoom.jpg 2x'];
+        var srcsetString = '../example-images/test_standard.jpg 1x,../example-images/test_zoom.jpg 2x';
+
+        api.swap(standard, zoom, srcsetArray);
+
+        equal(api.$image.attr("srcset"), srcsetString, "Standard image SRCSET changed");
+
+    });
+
     test(".teardown()", function() {
 
         api.teardown();


### PR DESCRIPTION
If you use the `srcset` attribute in Chrome, the swap function won't work because Chrome disregards the `src` attribute in favor of `srcset`.  This PR adds the capability to optionally set the `srcset` attribute via string or array.

For the argument type (optional string or array of strings), I put `string|Array.<string>=` per guidelines provided by usejsdoc.org, but I noticed you've been using String (with a capital S) for your string primative arguments - happy to update the PR to conform to that if you'd like, though. 

Thanks for writing this plugin!
