### PR TITLE
Check if outside using absolute dimesions

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -195,11 +195,14 @@
         var offset  = this.$target.offset();
         var pt = ly - offset.top;
         var pl = lx - offset.left;
-        var xt = pt * rh;
-        var xl = pl * rw;
+        var xt = rh > 0 ? pt * rh : dh / 2;
+        var xl = rw > 0 ? pl * rw : dw / 2;
+
+        var w1 = this.$target.width();
+        var h1 = this.$target.height();
 
         // Close if outside
-        if (xl < 0 || xt < 0 || xl > dw || xt > dh) {
+        if (pt < 0 || pl < 0 || pt > h1 || pl > w1) {
             this.hide();
         }
         else {


### PR DESCRIPTION
I've been seeing a bug where full images, which are smaller than the flyout in one dimension, are never shown. (for example a 400x2000 image in a 500x500 flyout)

This is the fix I'm now using. The zoomed image is centered across dimesions, in which it is smaller than the window (lines 198-199). The check to see if the mouse has left the target image is then performed using the absolute dimesions of the `$target` and the position of the pointer relative to it.

The build does still need to be run (I don't have access to node at the moment).
