### PR TITLE
Copy the style from the link to the float

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -82,6 +82,9 @@
         }
 
         this.$target.append(this.$flyout);
+        if (this.$link.attr('style') != undefined) {
+            this.$flyout.find('img').attr("style", this.$flyout.find('img').attr("style") + this.$link.attr('style'));
+        }
 
         w1 = this.$target.width();
         h1 = this.$target.height();


### PR DESCRIPTION
So that the float image can have background styles. It's useful when the float image is a transparent dynamic drawing lines(such as a road path) and background is an image (such as a map).