### PR TITLE
Fixed zoom image smaller than fly-out

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -100,6 +100,12 @@
         dw = this.$zoom.width() - w2;
         dh = this.$zoom.height() - h2;
 
+        // For the case where the zoom image is actually smaller than
+        // the flyout.
+        //
+        if(dw<0) dw=0;
+        if(dh<0) dh=0;
+
         rw = dw / w1;
         rh = dh / h1;
 

--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -31,7 +31,13 @@
         onHide: $.noop,
 
         // Callback function to execute when the cursor is moved while over the image.
-        onMove: $.noop
+        onMove: $.noop,
+
+        // Link attribute to retrieve the zoom image URL from, normally 'href'.
+        // Can be set to, for instance, 'data-zoom-url' if href points
+        // to something other than the large image.
+        //
+        linkAttribute: 'href'
 
     };
 
@@ -82,7 +88,7 @@
         if (this.opts.beforeShow.call(this) === false) return;
 
         if (!this.isReady) {
-            return this._loadImage(this.$link.attr('href'), function() {
+            return this._loadImage(this.$link.attr(this.opts.linkAttribute), function() {
                 if (self.isMouseOver || !testMouseOver) {
                     self.show(e);
                 }
@@ -281,7 +287,7 @@
             srcset: $.isArray(srcset) ? srcset.join() : srcset
         });
 
-        this.$link.attr('href', zoomHref);
+        this.$link.attr(this.opts.linkAttribute, zoomHref);
     };
 
     /**


### PR DESCRIPTION
For issue #88 

Fixed the problem where the fly-out size is smaller than the zoomed
image on either width or height.

Use case:
    My flyout is styled to display on the side of the target image
    at about 500x700 size. Some of the images on the site are larger
    than the preview image, but smaller than this box. It makes sense
    to still show them in fly-out, even if they don't scroll with the
    mouse.