### PR TITLE
Fixed zoom image smaller than fly-out

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -100,6 +100,12 @@
         dw = this.$zoom.width() - w2;
         dh = this.$zoom.height() - h2;
 
+        // For the case where the zoom image is actually smaller than
+        // the flyout.
+        //
+        if(dw<0) dw=0;
+        if(dh<0) dh=0;
+
         rw = dw / w1;
         rh = dh / h1;
 


### PR DESCRIPTION
For issue #88 

Fixed the problem where the fly-out size is smaller than the zoomed
image on either width or height.

Use case:
    My flyout is styled to display on the side of the target image
    at about 500x700 size. Some of the images on the site are larger
    than the preview image, but smaller than this box. It makes sense
    to still show them in fly-out, even if they don't scroll with the
    mouse.