### PR TITLE
Added linkAttribute option, defaulting to 'href'

### DIFF
--- a/src/easyzoom.js
+++ b/src/easyzoom.js
@@ -31,7 +31,13 @@
         onHide: $.noop,
 
         // Callback function to execute when the cursor is moved while over the image.
-        onMove: $.noop
+        onMove: $.noop,
+
+        // Link attribute to retrieve the zoom image URL from, normally 'href'.
+        // Can be set to, for instance, 'data-zoom-url' if href points
+        // to something other than the large image.
+        //
+        linkAttribute: 'href'
 
     };
 
@@ -82,7 +88,7 @@
         if (this.opts.beforeShow.call(this) === false) return;
 
         if (!this.isReady) {
-            return this._loadImage(this.$link.attr('href'), function() {
+            return this._loadImage(this.$link.attr(this.opts.linkAttribute), function() {
                 if (self.isMouseOver || !testMouseOver) {
                     self.show(e);
                 }
@@ -275,7 +281,7 @@
             srcset: $.isArray(srcset) ? srcset.join() : srcset
         });
 
-        this.$link.attr('href', zoomHref);
+        this.$link.attr(this.opts.linkAttribute, zoomHref);
     };
 
     /**


### PR DESCRIPTION
The point is to take an zoom image URL from something other than <a
href="..."> allowing to use the href link for other purposes. The
default is 'href', so it should be backward compatible.

For issue #90